### PR TITLE
Adding very primitive support to AWS CloudFront

### DIFF
--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -125,8 +125,14 @@ class S3_Uploads {
 
 		$bucket = strtok( $this->bucket, '/' );
 		$path   = substr( $this->bucket, strlen( $bucket ) );
+		
+		if ( defined( 'S3_CLOUDFRONT_DOMAIN_URI' ) && S3_CLOUDFRONT_DOMAIN_URI ) {
+			$path_beg = S3_CLOUDFRONT_DOMAIN_URI;
+		} else {
+			$path_beg = 'https://' . $bucket . '.s3.amazonaws.com';
+		}
 
-		return apply_filters( 's3_uploads_bucket_url', 'https://' . $bucket . '.s3.amazonaws.com' . $path );
+		return apply_filters( 's3_uploads_bucket_url', $path_beg . $path );
 	}
 
 	/**


### PR DESCRIPTION
This adds additional yet primitive support to AWS CloudFront by introducing  new wp-config.php constant - S3_CLOUDFRONT_DOMAIN_URI. If constant is present, URL to media assets will be adjusted according to S3_CLOUDFRONT_DOMAIN_URI rather direct link S3.

Sample addition to wp-config.php
define( 'S3_CLOUDFRONT_DOMAIN_URI', 'https://foo.com');